### PR TITLE
Add migrate:fresh --seed alias

### DIFF
--- a/volker.plugin.zsh
+++ b/volker.plugin.zsh
@@ -1,4 +1,5 @@
 alias v=volker
+alias mfs='volker artisan migrate:fresh --seed'
 alias vc='volker composer'
 alias vd='volker down'
 alias ve='volker enter'


### PR DESCRIPTION
Often on a project i want to run this command to get back to a clean slate, this is a handy little alias for running `php artisan migrate:fresh --seed` inside the volker container.